### PR TITLE
fixes call to depreciated set_axis_bgcolor in plt routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Requires
     matplotlib
     wxpython
     pyserial
+    distutils
 
 
 Usage

--- a/legoReactor.py
+++ b/legoReactor.py
@@ -13,6 +13,7 @@
 
 import time
 import sys
+from distutils.version import LooseVersion
 import numpy as np
 import wx
 import reactor as rct
@@ -98,7 +99,10 @@ class CalcFrame(gui.MyFrame1):
         self.axes1 = self.fig.add_subplot(211)
         self.axes2 = self.fig.add_subplot(212)
         self.axes3 = self.axes2.twinx()
-        self.axes1.set_facecolor('white')
+        if LooseVersion(matplotlib.__version__) >= LooseVersion('2.0.0'):
+            self.axes1.set_facecolor('white')
+        else:
+            self.axes1.set_axis_bgcolor('white')
         self.axes1.set_title('Reactor Power [MW] Trace', size=12)
 
         pylab.setp(self.axes1.get_xticklabels(), fontsize=8)

--- a/legoReactor.py
+++ b/legoReactor.py
@@ -98,7 +98,7 @@ class CalcFrame(gui.MyFrame1):
         self.axes1 = self.fig.add_subplot(211)
         self.axes2 = self.fig.add_subplot(212)
         self.axes3 = self.axes2.twinx()
-        self.axes1.set_axis_bgcolor('white')
+        self.axes1.set_facecolor('white')
         self.axes1.set_title('Reactor Power [MW] Trace', size=12)
 
         pylab.setp(self.axes1.get_xticklabels(), fontsize=8)

--- a/reactor.py
+++ b/reactor.py
@@ -27,7 +27,7 @@ class LegoReactor(object):
         self.scramToggle = False
         # For Storage/Plotting
         self.maxTime = 100.  # maximum time storage history [s]
-        dataStorLength = self.maxTime / self.tstep
+        dataStorLength = int(self.maxTime / self.tstep)
         self.time = np.zeros(dataStorLength)
         self.storVals = np.zeros((5, dataStorLength))
 


### PR DESCRIPTION
Matplotlib depreciated set_axis_bgcolor:

https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.set_axis_bgcolor.html

Also ensures an integer is passed to np.zeros()